### PR TITLE
Add dev script for ops-bedrock docker compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "clean": "pnpm recursive run clean; rm -rf node_modules packages/*/node_modules && echo 'Finished cleaning. Run `pnpm install && pnpm build` from root of repo to rebuild the repo.'",
+    "dev": "cd ops-bedrock && docker compose up",
     "bindings": "nx bindings @eth-optimism/contracts-bedrock",
     "build": "npx nx run-many --target=build",
     "test": "npx nx run-many --target=test",


### PR DESCRIPTION
Adds a new dev script to package.json that runs docker compose up in the ops-bedrock directory. This simplifies the local development workflow by providing a single command to start the development environment.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=vortex-field&projectId=fe333a8e53c3409cb931042ff00a8d65)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe333a8e53c3409cb931042ff00a8d65</projectId>-->